### PR TITLE
Adding support for FunduMoto style motor shields

### DIFF
--- a/DCCpp_Uno/Config.h
+++ b/DCCpp_Uno/Config.h
@@ -13,8 +13,9 @@ Part of DCC++ BASE STATION for the Arduino
 //
 //  0 = ARDUINO MOTOR SHIELD          (MAX 18V/2A PER CHANNEL)
 //  1 = POLOLU MC33926 MOTOR SHIELD   (MAX 28V/3A PER CHANNEL)
+//  2 = FUNDUMOTO MOTOR SHIELD        (MAX 18V/2A PER CHANNEL)
 
-#define MOTOR_SHIELD_TYPE   0
+#define MOTOR_SHIELD_TYPE   2
 
 /////////////////////////////////////////////////////////////////////////////////////
 //
@@ -55,4 +56,3 @@ Part of DCC++ BASE STATION for the Arduino
 #define MAC_ADDRESS {  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xEF }
 
 /////////////////////////////////////////////////////////////////////////////////////
-

--- a/DCCpp_Uno/DCCpp_Uno.h
+++ b/DCCpp_Uno/DCCpp_Uno.h
@@ -51,7 +51,7 @@ Part of DCC++ BASE STATION for the Arduino
 #elif MOTOR_SHIELD_TYPE == 2
 
   #define MOTOR_SHIELD_NAME "FUNDUMOTO MOTOR SHIELD"
-  #define FUTUMOTO_SHIELD
+  #define FUNDUMOTO_SHIELD
 
   #define SIGNAL_ENABLE_PIN_MAIN 10
   #define SIGNAL_ENABLE_PIN_PROG 11
@@ -80,7 +80,7 @@ Part of DCC++ BASE STATION for the Arduino
 
   #define ARDUINO_TYPE    "UNO"
 
-  #ifdef FUTUMOTO_SHIELD // With an Uno and FUTUMOTO Shield we need to do some tricks
+  #ifdef FUNDUMOTO_SHIELD // With an Uno and FUNDUMOTO Shield we need to do some tricks
     #define DCC_SIGNAL_PIN_MAIN 3         // Ardunio Uno  - uses OC2B
   #else
     #define DCC_SIGNAL_PIN_MAIN 10        // Ardunio Uno  - uses OC1B

--- a/DCCpp_Uno/DCCpp_Uno.h
+++ b/DCCpp_Uno/DCCpp_Uno.h
@@ -19,40 +19,6 @@ Part of DCC++ BASE STATION for the Arduino
 #define VERSION "1.2.1+"
 
 /////////////////////////////////////////////////////////////////////////////////////
-// AUTO-SELECT ARDUINO BOARD
-/////////////////////////////////////////////////////////////////////////////////////
-
-#ifdef ARDUINO_AVR_MEGA                   // is using Mega 1280, define as Mega 2560 (pinouts and functionality are identical)
-  #define ARDUINO_AVR_MEGA2560
-#endif
-
-#if defined  ARDUINO_AVR_UNO
-
-  #define ARDUINO_TYPE    "UNO"
-
-  #define DCC_SIGNAL_PIN_MAIN 10          // Ardunio Uno  - uses OC1B
-  #define DCC_SIGNAL_PIN_PROG 5           // Arduino Uno  - uses OC0B
-
-  #if COMM_INTERFACE != 0                 // Serial was not selected
-
-    #error CANNOT COMPILE - DCC++ FOR THE UNO CAN ONLY USE SERIAL COMMUNICATION - PLEASE SELECT THIS IN THE CONFIG FILE
-
-  #endif
-
-#elif defined  ARDUINO_AVR_MEGA2560
-
-  #define ARDUINO_TYPE    "MEGA"
-
-  #define DCC_SIGNAL_PIN_MAIN 12          // Arduino Mega - uses OC1B
-  #define DCC_SIGNAL_PIN_PROG 2           // Arduino Mega - uses OC3B
-
-#else
-
-  #error CANNOT COMPILE - DCC++ ONLY WORKS WITH AN ARDUINO UNO OR AN ARDUINO MEGA 1280/2560
-
-#endif
-
-/////////////////////////////////////////////////////////////////////////////////////
 // SELECT MOTOR SHIELD
 /////////////////////////////////////////////////////////////////////////////////////
 
@@ -82,9 +48,61 @@ Part of DCC++ BASE STATION for the Arduino
   #define DIRECTION_MOTOR_CHANNEL_PIN_A 7
   #define DIRECTION_MOTOR_CHANNEL_PIN_B 8
 
+#elif MOTOR_SHIELD_TYPE == 2
+
+  #define MOTOR_SHIELD_NAME "FUNDUMOTO MOTOR SHIELD"
+  #define FUTUMOTO_SHIELD
+
+  #define SIGNAL_ENABLE_PIN_MAIN 10
+  #define SIGNAL_ENABLE_PIN_PROG 11
+
+  #define CURRENT_MONITOR_PIN_MAIN A0
+  #define CURRENT_MONITOR_PIN_PROG A1
+
+  #define DIRECTION_MOTOR_CHANNEL_PIN_A 12
+  #define DIRECTION_MOTOR_CHANNEL_PIN_B 13
+
 #else
 
   #error CANNOT COMPILE - PLEASE SELECT A PROPER MOTOR SHIELD TYPE
+
+#endif
+
+/////////////////////////////////////////////////////////////////////////////////////
+// AUTO-SELECT ARDUINO BOARD
+/////////////////////////////////////////////////////////////////////////////////////
+
+#ifdef ARDUINO_AVR_MEGA                   // is using Mega 1280, define as Mega 2560 (pinouts and functionality are identical)
+  #define ARDUINO_AVR_MEGA2560
+#endif
+
+#if defined  ARDUINO_AVR_UNO
+
+  #define ARDUINO_TYPE    "UNO"
+
+  #ifdef FUTUMOTO_SHIELD // With an Uno and FUTUMOTO Shield we need to do some tricks
+    #define DCC_SIGNAL_PIN_MAIN 3         // Ardunio Uno  - uses OC2B
+  #else
+    #define DCC_SIGNAL_PIN_MAIN 10        // Ardunio Uno  - uses OC1B
+  #endif
+  #define DCC_SIGNAL_PIN_PROG 5           // Arduino Uno  - uses OC0B
+
+  #if COMM_INTERFACE != 0                 // Serial was not selected
+
+    #error CANNOT COMPILE - DCC++ FOR THE UNO CAN ONLY USE SERIAL COMMUNICATION - PLEASE SELECT THIS IN THE CONFIG FILE
+
+  #endif
+
+#elif defined  ARDUINO_AVR_MEGA2560
+
+  #define ARDUINO_TYPE    "MEGA"
+
+  #define DCC_SIGNAL_PIN_MAIN 12          // Arduino Mega - uses OC1B
+  #define DCC_SIGNAL_PIN_PROG 2           // Arduino Mega - uses OC3B
+
+#else
+
+  #error CANNOT COMPILE - DCC++ ONLY WORKS WITH AN ARDUINO UNO OR AN ARDUINO MEGA 1280/2560
 
 #endif
 
@@ -131,5 +149,3 @@ Part of DCC++ BASE STATION for the Arduino
 /////////////////////////////////////////////////////////////////////////////////////
 
 #endif
-
-

--- a/DCCpp_Uno/DCCpp_Uno.ino
+++ b/DCCpp_Uno/DCCpp_Uno.ino
@@ -272,8 +272,8 @@ void setup(){
   
   // Direction Pin for Motor Shield Channel A - MAIN OPERATIONS TRACK
 
-  // Need to use timer2 instead of timer1 when using the FUTUMOTO shield on an Uno
-  #if defined(FUTUMOTO_SHIELD) && defined(ARDUINO_AVR_UNO)
+  // Need to use timer2 instead of timer1 when using the FUNDUMOTO shield on an Uno
+  #if defined(FUNDUMOTO_SHIELD) && defined(ARDUINO_AVR_UNO)
     // Controlled by Arduino 8-bit TIMER 2 / OC2B Interrupt Pin
     // Values for 8-bit OCR2A and OCR2B registers calibrated for 1:64 prescale at 16 MHz clock frequency
     // Resulting waveforms are 200 microseconds for a ZERO bit and 116 microseconds for a ONE bit with as-close-as-possible to 50% duty cycle
@@ -338,8 +338,8 @@ void setup(){
 
   mainRegs.loadPacket(1,RegisterList::idlePacket,2,0);    // load idle packet into register 1    
 
-  // Need to use timer2 instead of timer1 when using the FUTUMOTO shield on an Uno
-  #if defined(FUTUMOTO_SHIELD) && defined(ARDUINO_AVR_UNO)
+  // Need to use timer2 instead of timer1 when using the FUNDUMOTO shield on an Uno
+  #if defined(FUNDUMOTO_SHIELD) && defined(ARDUINO_AVR_UNO)
     bitSet(TIMSK2,OCIE2B);    // enable interrupt vector for Timer 2 Output Compare B Match (OCR2B)
   #else
     bitSet(TIMSK1,OCIE1B);    // enable interrupt vector for Timer 1 Output Compare B Match (OCR1B)
@@ -492,7 +492,7 @@ void setup(){
 
 // NOW USE THE ABOVE MACRO TO CREATE THE CODE FOR EACH INTERRUPT
 
-#if defined(FUTUMOTO_SHIELD) && defined(ARDUINO_AVR_UNO)
+#if defined(FUNDUMOTO_SHIELD) && defined(ARDUINO_AVR_UNO)
 
 ISR(TIMER2_COMPB_vect){              // set interrupt service for OCR2B of TIMER-2 which flips direction bit of Motor Shield Channel A controlling Main Track
   DCC_SIGNAL(mainRegs,2)

--- a/DCCpp_Uno/SerialCommand.cpp
+++ b/DCCpp_Uno/SerialCommand.cpp
@@ -453,10 +453,20 @@ void SerialCommand::parse(char *com){
 
     Serial.println("\nEntering Diagnostic Mode...");
     delay(1000);
-    
-    bitClear(TCCR1B,CS12);    // set Timer 1 prescale=8 - SLOWS NORMAL SPEED BY FACTOR OF 8
-    bitSet(TCCR1B,CS11);
-    bitClear(TCCR1B,CS10);
+
+    #if defined(FUTUMOTO_SHIELD) && defined(ARDUINO_AVR_UNO) // UNO + FUTUMOTO Shield
+
+      bitSet(TCCR2B,CS22);    // set Timer 2 prescale=256 - SLOWS NORMAL SPEED BY A FACTOR OF 4
+      bitClear(TCCR2B,CS21);
+      bitClear(TCCR2B,CS20);
+
+    #else
+
+      bitClear(TCCR1B,CS12);    // set Timer 1 prescale=8 - SLOWS NORMAL SPEED BY FACTOR OF 8
+      bitSet(TCCR1B,CS11);
+      bitClear(TCCR1B,CS10);
+
+    #endif
 
     #ifdef ARDUINO_AVR_UNO      // Configuration for UNO
 

--- a/DCCpp_Uno/SerialCommand.cpp
+++ b/DCCpp_Uno/SerialCommand.cpp
@@ -454,7 +454,7 @@ void SerialCommand::parse(char *com){
     Serial.println("\nEntering Diagnostic Mode...");
     delay(1000);
 
-    #if defined(FUTUMOTO_SHIELD) && defined(ARDUINO_AVR_UNO) // UNO + FUTUMOTO Shield
+    #if defined(FUNDUMOTO_SHIELD) && defined(ARDUINO_AVR_UNO) // UNO + FUNDUMOTO Shield
 
       bitSet(TCCR2B,CS22);    // set Timer 2 prescale=256 - SLOWS NORMAL SPEED BY A FACTOR OF 4
       bitClear(TCCR2B,CS21);


### PR DESCRIPTION
This adds support for the FutuMoto style L298P motor shields.
To use them, jumper 3->12, 5->13, and turn off the onboard jumper for the "OPT" (power transfer between shield and Arduino)